### PR TITLE
Make plugins aware of baseurl setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ On smaller screens, tapping on the <span>&#8853;</span> symbol will open up the 
 
 ### Full width image
 
-This tag inserts an image that spans both the main content column and the side column. Full-width IOW:
+This tag inserts an image that spans both the main content column and the side column:
 
 ```
 blah blah 
-{% fullwidth 'url/to/image' 'A caption for the image' %}
+{% fullwidth 'assets/img/rhino.png' 'A caption for the image' %}
 blah
 ```
 
-Note the absence of the leading slash. Always use just the folder name without the leading slash. This is incorrect: `/url/to/image`
+Note the absence of a leading slash in the image url. This is incorrect: `/assets/img/rhino.png`
 
 Also note that fullwidth images need to be included on their own line in order for the captions to work correctly.
 
@@ -90,23 +90,23 @@ This tag inserts an image that is confined to the main content column:
 
 ```
 blah blah
-{% maincolumn 'path/to/image' 'This is the caption' %}
+{% maincolumn 'assets/img/rhino.png' 'This is the caption' %}
 blah
 ```
 
-No need for an ID in this tag because it doesn't have any doohickies that open and close on narrow screens. Again note the absence of the leading slash. Always use just the folder name without the leading slash. This is incorrect: `/path/to/image`
+No need for an ID in this tag because it doesn't have any doohickies that open and close on narrow screens. Again note the absence of the leading slash in the image url. This is incorrect: `/assets/img/rhino.png`
 
-Just like fullwidth images, main column images need to be included on their own line in order for the captions to work correctly.
+And just like fullwidth images, main column images need to be included on their own line in order for the captions to work correctly.
 
 ### Margin figure
 
 This tag inserts and image in the side column area. Note that an id needs to be specified:
 
 ```
-blah blah {% marginfigure 'margin-figure-id' 'path/to/image' 'This is the caption' %} blah
+blah blah {% marginfigure 'margin-figure-id' 'assets/img/rhino.png' 'This is the caption' %} blah
 ```
 
-This needs an ID parameter so that it can be clicked and opened on small screens. Again note the absence of the leading slash. Always use just the folder name without the leading slash. This is incorrect: `/path/to/image`
+This needs an ID parameter so that it can be clicked and opened on small screens. Again note the absence of the leading slash in the image url. This is incorrect: `/assets/img/rhino.png`
 
 ### New thought
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@ I'm not going to go into great detail here. I am just going to assume that anyon
 So copy, pull, download a zipfile or whatever and fire it up. 
 
 ```
-%> cd ~/thatPlaceYouPutIt/tufte-jekyll
-%> jekyll build
-%> jekyll serve -w
+cd ~/thatPlaceYouPutIt/tufte-jekyll
+jekyll build
+jekyll serve -w
 ```
 
-And then point your browser at localhost:4000/tufte-jekyll/
+And then point your browser at localhost:4000/tufte-jekyll
+
+You can also use `jekyll serve -w --baseurl ''` to remove `/tufte-jekyll` from the url and serve your site directly from localhost:4000. This only affects your local preview. See [Setting your baseurl correctly](#setting-your-baseurl-correctly) for more details.
 
 ## Configuration
 
 ### Jekyll site building options
 
-I have created a very simple site options file in the ```/_data``` directory that contains two settings currently. The file in the github repo looks like this:
+I have created a very simple site options file in the ```_data``` directory that contains two settings currently. The file in the github repo looks like this:
 ```
 mathjax: true
 lato_font_load: true
@@ -42,9 +44,7 @@ You can edit the ```_data/social.yml``` file and put in your own information for
 
 ### Silly-ass badge in the upper left
 
-In the ```/assets/img``` directory is a file called ```badge_1.png```. This file's parent is ```badge_1.psd``` and is an editable photoshop file with layers for the letters comprising the initials. Change them to suit your fancy. Or just substitute another badge in its place. You can edit the ```/_includes/header.html``` file and change the file that it points too. Find your favorite Tufte emoji and fly your freak flag proudly.
-
-
+In the ```assets/img``` directory is a file called ```badge_1.png```. This file's parent is ```badge_1.psd``` and is an editable photoshop file with layers for the letters comprising the initials. Change them to suit your fancy. Or just substitute another badge in its place. You can edit the ```_includes/header.html``` file and change the file that it points too. Find your favorite Tufte emoji and fly your freak flag proudly.
 
 ## Some things about the things
 
@@ -57,7 +57,7 @@ Note that these tags *have been altered* from Version 1 of this theme to accommo
 This tag inserts a *sidenote* in the content, which is like a footnote, only its in the spacious right-hand column. It is automatically numbered, starting over on each page. Just put it in the content like you would insert a footnote like so:
 
 ```
-blah lorem blah{% sidenote 'sidenote-id' 'This is a random sidenote'%} blah blah
+blah lorem blah{% sidenote 'sidenote-id' 'This is a random sidenote' %} blah blah
 ```
 And it will add the html spans and superscripts. On smaller screens, tapping on the number will reveal the sidenote!
 
@@ -66,7 +66,7 @@ And it will add the html spans and superscripts. On smaller screens, tapping on 
 This tag is essentially the same as a sidenote, but heh, no number. Like this:
 
 ```
-lorem nobeer toasty critters{% marginnote 'margin-note-id' 'Random thought when drinking'%} continue train of thought
+lorem nobeer toasty critters{% marginnote 'margin-note-id' 'Random thought when drinking' %} continue train of thought
 ```
 On smaller screens, tapping on the <span>&#8853;</span> symbol will open up the margin note.
 
@@ -75,55 +75,66 @@ On smaller screens, tapping on the <span>&#8853;</span> symbol will open up the 
 This tag inserts an image that spans both the main content column and the side column. Full-width IOW:
 
 ```
-blah blah {% fullwidth '/url/to/image' 'A caption for the image'}
+blah blah 
+{% fullwidth 'url/to/image' 'A caption for the image' %}
+blah
 ```
+
+Note the absence of the leading slash. Always use just the folder name without the leading slash. This is incorrect: `/url/to/image`
+
+Also note that fullwidth images need to be included on their own line in order for the captions to work correctly.
 
 ### Main column image
 
 This tag inserts an image that is confined to the main content column:
 
 ```
-blah blah{% maincolumn '/path/to/image' 'This is the caption' %} blah
+blah blah
+{% maincolumn 'path/to/image' 'This is the caption' %}
+blah
 ```
-No need for an ID in this tag because it doesn't have any doohickies that open and close on narrow screens.
+
+No need for an ID in this tag because it doesn't have any doohickies that open and close on narrow screens. Again note the absence of the leading slash. Always use just the folder name without the leading slash. This is incorrect: `/path/to/image`
+
+Just like fullwidth images, main column images need to be included on their own line in order for the captions to work correctly.
 
 ### Margin figure
 
 This tag inserts and image in the side column area. Note that an id needs to be specified:
 
 ```
-blah blah {% marginfigure 'margin-figure-id' '/path/to/image' 'This is the caption' %} blah
+blah blah {% marginfigure 'margin-figure-id' 'path/to/image' 'This is the caption' %} blah
 ```
-This needs an ID parameter so that it can be clicked and opened on small screens.
+
+This needs an ID parameter so that it can be clicked and opened on small screens. Again note the absence of the leading slash. Always use just the folder name without the leading slash. This is incorrect: `/path/to/image`
 
 ### New thought
 
 This tag will render its contents in small caps. Useful at the beginning of new sections:
 
 ```
-{% newthought 'This will be rendered in small caps %} blah blah
+{% newthought 'This will be rendered in small caps' %} blah blah
 ```
+
 ### Mathjax
 
 Totally used this functionality from a [gist by Jessy Cowan-Sharpe](https://gist.github.com/jessykate/834610) to make working with Mathjax expressions a little easier. Short version, wrap inline math in a tag pair thusly: ```{% m %}mathjax expression{% em %}``` and wrap bigger block level stuff with ```{% math %}mathjax expression{% endmath %}```
 
 As a side note - if you do not need the math ability, navigate to the ```_data/options.yml``` file and change the mathjax to 'false' and it will not load the mathjax javascript.
 
-### Which brings me to this
+### Setting your baseurl correctly
 
-Getting this thing to display properly on *Github Pages* revealed an issue with path names. So here is the deal: In the ```/_config.yml``` file is a setting called *baseurl*. This is used by the Jekyll engine to construct all the proper links in the static site. This is all well and good for the bones of the site. Right now it is set to '*tufte-jekyll*' and all the links are created assuming that is the root path. On your local installation, if you tire of typing in ```localhost:4000/tufte-jekyll``` all you need to do is change that baseurl parameter to '/'.
+In the `_config.yml` file is a setting called `baseurl`. This is used by the Jekyll engine to construct all the proper links in the static site. Right now it is set to `/tufte-jekyll` since this project is using Github Pages and you are required to set the project name as the baseurl to serve from Github Pages.
 
-However... When writing content that includes images that are inside the custom Liquid tags, you must hard-code the *entire* path for your intended site configuration. One might think it possible to enter an image path something like ```{{site.baseurl}}/assets/img/someimage.png``` and it would be properly fleshed out. But my Liquid tags are pretty dumb, and they do not recursively call the Liquid engine to properly build the url. At the present, my N00b status in the Ruby language has prevented me from fixing this problem. So what you will need to do is explicitly embed the ```site.baseurl``` in the url. So for one of the image tags, you might code it as:
+Set this to your own project name if you're going to serve your site from Github Pages. Be sure to include the leading slash, and no trailing slash. For example: `/my-project-name`
 
-```
-{% marginfigure 'mf-id-1' '/tufte-jekyll/assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.'  %}
-```
+For a full explanation of setting your baseurl to work with Github Pages, see the [Project Page URL Structure](http://jekyllrb.com/docs/github-pages/#project-page-url-structure) section of the Jekyll documentation.
 
-Here are some discussions about the reason behind the baseurl business:
+To serve from anywhere else besides Github Pages, use a blank baseurl in your `_config.yml` file:
 
-* [Jekyll docs](http://jekyllrb.com/docs/configuration/)
-* [Parker Moore](http://blog.parkermoore.de/2014/04/27/clearing-up-confusion-around-baseurl/)
-* [Andrew Shell](http://blog.andrewshell.org/understanding-baseurl/)
+    baseurl:
+
+This is `baseurl:` with nothing after it. Not even a space.
 
 ### Rakefile
 
@@ -134,6 +145,4 @@ There is another rakefile (UploadtoGithub.Rakefile) included that only has one t
 ### To-do list
 
 One very cool option would be for someone to monkey with the SASS file so that when the full-width page option is picked *margin notes* and *side notes* can be used, but opened by the same clicking technique as is implemented on smaller screens.
-
-
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A sample site with self-documenting content is available [here](http://clayh53.g
 
 I'm not going to go into great detail here. I am just going to assume that anyone interested in either Jekyll, Edward Tufte's work or Github has some basic skills. I created this with Ruby 2.2.0 and Jekyll 2.5.3. There is absolutely nothing exotic going on here, so you can probably make any recent version of Jekyll work with this setup.
 
-So copy, pull, download a zipfile or whatever and fire it up. 
+So copy, pull, download a zipfile or whatever and fire it up.
 
 ```
 cd ~/thatPlaceYouPutIt/tufte-jekyll
@@ -37,7 +37,6 @@ Removing either 'true' value will prevent the jekyll site building process from 
 
 I am using Sass to create the css file used by this theme. If you would like to change things like fonts, text colors, background colors and so forth, edit the ```_scss/_settings.scss``` file. This file gets loaded first when Jekyll constructs the master CSS file from the tufte.scss SASS file, and contains SASS variables that influence the appearance of the site. The one variable that may be of interest to some is the ```$link-style``` variable, which can be set to either ```underline``` or ```color```. This will determine if your links are styled using the ```$contrast-color``` variable with no underlining, or whether they are styled using light underlining as seen on the [*tufte-css*](https://github.com/edwardtufte/tufte-css) repo.  
 
-
 ### Social icons
 
 You can edit the ```_data/social.yml``` file and put in your own information for the footer links
@@ -48,7 +47,7 @@ In the ```assets/img``` directory is a file called ```badge_1.png```. This file'
 
 ## Some things about the things
 
-I needed to create several custom Liquid tags to wrap content in the right kind of tags. You will create your posts in the normal way in the ```_posts``` directory, and then edit them with Github-Flavored Markdown. To all that GFM goodness, you can use the following custom Liquid tags in your content area. 
+I needed to create several custom Liquid tags to wrap content in the right kind of tags. You will create your posts in the normal way in the ```_posts``` directory, and then edit them with Github-Flavored Markdown. To all that GFM goodness, you can use the following custom Liquid tags in your content area.
 
 Note that these tags *have been altered* from Version 1 of this theme to accommodate some responsive features, namely the ability to reveal hidden sidenotes, margin notes and margin figures by tapping either a superscript or a symbol on small screens. This requires you to add a parameter to the tag that is a unique *ID* for each tag instance on the page. What the id is called is not important, but it is important that it be unique for each individual element on the page. I would recommend in the interest of sanity to give names that are descriptive, like ```'sn-id-1'``` or ```'mf-id-rhino'```.
 
@@ -75,12 +74,20 @@ On smaller screens, tapping on the <span>&#8853;</span> symbol will open up the 
 This tag inserts an image that spans both the main content column and the side column:
 
 ```
-blah blah 
+blah blah
 {% fullwidth 'assets/img/rhino.png' 'A caption for the image' %}
 blah
 ```
 
-Note the absence of a leading slash in the image url. This is incorrect: `/assets/img/rhino.png`
+or
+
+```
+blah blah
+{% fullwidth 'http://example.com/image.jpg' 'A caption for the image' %}
+blah
+```
+
+Note the absence of a leading slash in the image url when using relative file paths. (This is incorrect: `/assets/img/rhino.png`)
 
 Also note that fullwidth images need to be included on their own line in order for the captions to work correctly.
 
@@ -94,7 +101,15 @@ blah blah
 blah
 ```
 
-No need for an ID in this tag because it doesn't have any doohickies that open and close on narrow screens. Again note the absence of the leading slash in the image url. This is incorrect: `/assets/img/rhino.png`
+or
+
+```
+blah blah
+{% maincolumn 'http://example.com/image.jpg' 'This is the caption' %}
+blah
+```
+
+No need for an ID in this tag because it doesn't have any doohickies that open and close on narrow screens. Again note the absence of the leading slash in the image url when using relative file paths. (This is incorrect: `/assets/img/rhino.png`)
 
 And just like fullwidth images, main column images need to be included on their own line in order for the captions to work correctly.
 
@@ -106,7 +121,13 @@ This tag inserts and image in the side column area. Note that an id needs to be 
 blah blah {% marginfigure 'margin-figure-id' 'assets/img/rhino.png' 'This is the caption' %} blah
 ```
 
-This needs an ID parameter so that it can be clicked and opened on small screens. Again note the absence of the leading slash in the image url. This is incorrect: `/assets/img/rhino.png`
+or
+
+```
+blah blah {% marginfigure 'margin-figure-id' 'http://example.com/image.jpg' 'This is the caption' %} blah
+```
+
+This needs an ID parameter so that it can be clicked and opened on small screens. Again note the absence of the leading slash in the image url when using relative file paths. (This is incorrect: `/assets/img/rhino.png`)
 
 ### New thought
 
@@ -132,17 +153,18 @@ For a full explanation of setting your baseurl to work with Github Pages, see th
 
 To serve from anywhere else besides Github Pages, use a blank baseurl in your `_config.yml` file:
 
-    baseurl:
+```
+baseurl:
+```
 
 This is `baseurl:` with nothing after it. Not even a space.
 
 ### Rakefile
 
-I have added a boilerplate Rakefile directly from the [jekyll-rake-boilerplate repo](https://github.com/gummesson/jekyll-rake-boilerplate). This saves you a small amount of time by prepending the date on a post name and populated the bare minimum of YAML front matter in the file. Please visit the link to the repo to find out how it runs. One thing to note is that there should be *no* space between the task and the opening bracket of your file name. ```rake post["Title"]``` will work while ```rake post ["Title"]``` will not. 
+I have added a boilerplate Rakefile directly from the [jekyll-rake-boilerplate repo](https://github.com/gummesson/jekyll-rake-boilerplate). This saves you a small amount of time by prepending the date on a post name and populated the bare minimum of YAML front matter in the file. Please visit the link to the repo to find out how it runs. One thing to note is that there should be *no* space between the task and the opening bracket of your file name. ```rake post["Title"]``` will work while ```rake post ["Title"]``` will not.
 
 There is another rakefile (UploadtoGithub.Rakefile) included that only has one task in it - an automated upload to a *Github Pages* location of the site. This is necessary because of the plugins used by this theme. It does scary stuff like move your ```_site``` somewhere safe, delete everything, move the ```_site``` back and then do a commit to the ```gh-pages``` branch of your repository. You can read about it [here](http://blog.nitrous.io/2013/08/30/using-jekyll-plugins-on-github-pages.html). You would only need to use this if you are using Github project pages to host your site. Integration with the existing Rakefile is left as an exercise for the reader.
 
 ### To-do list
 
 One very cool option would be for someone to monkey with the SASS file so that when the full-width page option is picked *margin notes* and *side notes* can be used, but opened by the same clicking technique as is implemented on smaller screens.
-

--- a/_plugins/fullwidth.rb
+++ b/_plugins/fullwidth.rb
@@ -12,7 +12,8 @@ require "shellwords"
     end
 
     def render(context)
-      "<figure class='fullwidth'><img  src='#{@text[0]}'/>" +
+      baseurl = context.registers[:site].config['baseurl']
+      "<figure class='fullwidth'><img src='#{baseurl}/#{@text[0]}'/>"+
       "<figcaption>#{@text[1]}</figcaption></figure>"
     end
   end

--- a/_plugins/fullwidth.rb
+++ b/_plugins/fullwidth.rb
@@ -1,10 +1,11 @@
 ## This has a fairly harmless hack that wraps the img tag in a div to prevent it from being
 ## wrapped in a paragraph tag instead, which would totally fuck things up layout-wise
-## Usage {% fullwidth /path/to/image 'caption goes here in quotes' %}
+## Usage {% fullwidth 'path/to/image' 'caption goes here in quotes' %}
 #
 module Jekyll
   class RenderFullWidthTag < Liquid::Tag
-require "shellwords"
+    
+    require "shellwords"
 
     def initialize(tag_name, text, tokens)
       super
@@ -13,8 +14,13 @@ require "shellwords"
 
     def render(context)
       baseurl = context.registers[:site].config['baseurl']
-      "<figure class='fullwidth'><img src='#{baseurl}/#{@text[0]}'/>"+
-      "<figcaption>#{@text[1]}</figcaption></figure>"
+      if @text[0].start_with?('http://', 'https://')
+        "<figure class='fullwidth'><img src='#{@text[0]}'/>"+
+        "<figcaption>#{@text[1]}</figcaption></figure>"
+      else
+        "<figure class='fullwidth'><img src='#{baseurl}/#{@text[0]}'/>"+
+        "<figcaption>#{@text[1]}</figcaption></figure>"
+      end
     end
   end
 end

--- a/_plugins/main_column_img.rb
+++ b/_plugins/main_column_img.rb
@@ -1,6 +1,6 @@
-## Liquid tag 'maincolumn-figure' used to add image data that fits within the main column
-## area of the layout
-## Usage {% maincolumn /path/to/image 'This is the caption' %}
+## Liquid tag 'maincolumn-figure' used to add image data that fits within the
+## main column area of the layout
+## Usage {% maincolumn 'path/to/image' 'This is the caption' %}
 #
 module Jekyll
   class RenderMainColumnTag < Liquid::Tag
@@ -14,7 +14,11 @@ module Jekyll
 
     def render(context)
       baseurl = context.registers[:site].config['baseurl']
-      "<figure><figcaption>#{@text[1]}</figcaption><img src='#{baseurl}/#{@text[0]}'/></figure>"
+      if @text[0].start_with?('http://', 'https://')
+        "<figure><figcaption>#{@text[1]}</figcaption><img src='#{@text[0]}'/></figure>"
+      else
+        "<figure><figcaption>#{@text[1]}</figcaption><img src='#{baseurl}/#{@text[0]}'/></figure>"
+      end
     end
   end
 end

--- a/_plugins/main_column_img.rb
+++ b/_plugins/main_column_img.rb
@@ -13,7 +13,8 @@ module Jekyll
     end
 
     def render(context)
-      "<figure><figcaption>#{@text[1]}</figcaption><img src='#{@text[0]}'/></figure>"
+      baseurl = context.registers[:site].config['baseurl']
+      "<figure><figcaption>#{@text[1]}</figcaption><img src='#{baseurl}/#{@text[0]}'/></figure>"
     end
   end
 end

--- a/_plugins/margin_figure.rb
+++ b/_plugins/margin_figure.rb
@@ -13,9 +13,10 @@ module Jekyll
     end
 
     def render(context)
+            baseurl = context.registers[:site].config['baseurl']
             "<label for='#{@text[0]}' class='margin-toggle'>&#8853;</label>"+
             "<input type='checkbox' id='#{@text[0]}' class='margin-toggle'/>"+
-            "<span class='marginnote'><img class='fullwidth' src='#{@text[1]}'/>#{@text[2]}</span>"
+            "<span class='marginnote'><img class='fullwidth' src='#{baseurl}/#{@text[1]}'/><br>#{@text[2]}</span>"
 
     end
   end

--- a/_plugins/margin_figure.rb
+++ b/_plugins/margin_figure.rb
@@ -1,6 +1,6 @@
-## Liquid tag 'maincolumn' used to add image data that fits within the main column
-## area of the layout
-## Usage {% marginfigure /path/to/image 'This is the caption' %}
+## Liquid tag 'maincolumn' used to add image data that fits within the main
+## column area of the layout
+## Usage {% marginfigure 'margin-id-whatever' 'path/to/image' 'This is the caption' %}
 #
 module Jekyll
   class RenderMarginFigureTag < Liquid::Tag
@@ -13,11 +13,16 @@ module Jekyll
     end
 
     def render(context)
-            baseurl = context.registers[:site].config['baseurl']
-            "<label for='#{@text[0]}' class='margin-toggle'>&#8853;</label>"+
-            "<input type='checkbox' id='#{@text[0]}' class='margin-toggle'/>"+
-            "<span class='marginnote'><img class='fullwidth' src='#{baseurl}/#{@text[1]}'/><br>#{@text[2]}</span>"
-
+      baseurl = context.registers[:site].config['baseurl']
+      if @text[1].start_with?('http://', 'https://')
+        "<label for='#{@text[0]}' class='margin-toggle'>&#8853;</label>"+
+        "<input type='checkbox' id='#{@text[0]}' class='margin-toggle'/>"+
+        "<span class='marginnote'><img class='fullwidth' src='#{@text[1]}'/><br>#{@text[2]}</span>"
+      else
+        "<label for='#{@text[0]}' class='margin-toggle'>&#8853;</label>"+
+        "<input type='checkbox' id='#{@text[0]}' class='margin-toggle'/>"+
+        "<span class='marginnote'><img class='fullwidth' src='#{baseurl}/#{@text[1]}'/><br>#{@text[2]}</span>"
+      end
     end
   end
 end

--- a/_posts/2015-02-19-tufte-style-jekyll-blog.md
+++ b/_posts/2015-02-19-tufte-style-jekyll-blog.md
@@ -90,9 +90,9 @@ For these reasons, Tufte CSS encourages caution before reaching for a list eleme
 
 ### Margin Figures
 
-{% marginfigure 'mf-id-1' '/tufte-jekyll/assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.'  %}Images and graphics play an integral role in Tufte’s work. To place figures in the margin, use the custom margin figure liquid tag included in the ```_plugins``` directory like so: 
+{% marginfigure 'mf-id-1' 'assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.'  %}Images and graphics play an integral role in Tufte’s work. To place figures in the margin, use the custom margin figure liquid tag included in the ```_plugins``` directory like so: 
 
-```{{ "{% marginfigure 'mf-id-whatever' '/assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.' "}} %}```. 
+```{{ "{% marginfigure 'mf-id-whatever' 'assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.' "}} %}```. 
 
 Note that this tag has *three* parameters. The first is an arbitrary id. This parameter can be named anything as long as it is unique to this post. The second parameter is the path to the image. And the final parameter is whatever caption you want to be displayed with the figure.  All parameters *must* be enclosed in quotes for this simple liquid tag to work!
 
@@ -100,21 +100,21 @@ Note that this tag has *three* parameters. The first is an arbitrary id. This pa
 
 If you need a full-width image or figure, another custom liquid tag is available to use. Oddly enough, it is named 'fullwidth', and this markup:
 
-```{{ "{% fullwidth '/assets/img/napoleons-march.png' 'Napoleon's March (Edward Tufte’s English translation)' "}} %}```
+```{{ "{% fullwidth 'assets/img/napoleons-march.png' 'Napoleon's March (Edward Tufte’s English translation)' "}} %}```
 
 Yields this:
 
-{% fullwidth '/tufte-jekyll/assets/img/napoleons-march.png' "Napoleon's March (Edward Tufte’s English translation)" %}
+{% fullwidth 'assets/img/napoleons-march.png' "Napoleon's March (Edward Tufte’s English translation)" %}
 
 ### Main Column Figures
 
 Besides margin and full width figures, you can of course also include figures constrained to the main column. Yes, you guessed it, a custom liquid tag rides to the rescue once again:
 
-```{{ "{% maincolumn '/assets/img/export-imports.png' 'From Edward Tufte, *Visual Display of Quantitative Information*, page 92' "}} %}```
+```{{ "{% maincolumn 'assets/img/export-imports.png' 'From Edward Tufte, *Visual Display of Quantitative Information*, page 92' "}} %}```
 
 yields this:
 
-{% maincolumn '/tufte-jekyll/assets/img/exports-imports.png' 'From Edward Tufte, *Visual Display of Quantitative Information*, page 92' %}
+{% maincolumn 'assets/img/exports-imports.png' 'From Edward Tufte, *Visual Display of Quantitative Information*, page 92' %}
 
 ## Sidenotes and Margin notes
 

--- a/_posts/2015-02-19-tufte-style-jekyll-blog.md
+++ b/_posts/2015-02-19-tufte-style-jekyll-blog.md
@@ -6,7 +6,7 @@ categories: jekyll css
 ---
 ## Introduction
 
-{% newthought 'The Tufte Jekyll theme' %} is an attempt to create a website design with the look and feel of Edward Tufte's books and handouts. Tufte’s style is known for its extensive use of sidenotes, tight integration of graphics with text, and well-set typography.<!--more--> The idea for this project is essentially cribbed wholesale from Tufte and R Markdown's Tufte Handout format{% sidenote 'One'  'See [tufte-latex.github.io/tufte-latex/](https://tufte-latex.github.io/tufte-latex/') and [rmarkdown.rstudio.com/tufte_handout_format](http://rmarkdown.rstudio.com/tufte_handout_format.html) %} This page is an adaptation of the [Tufte Handout PDF](http://rmarkdown.rstudio.com/examples/tufte-handout.pdf).
+{% newthought 'The Tufte Jekyll theme' %} is an attempt to create a website design with the look and feel of Edward Tufte's books and handouts. Tufte’s style is known for its extensive use of sidenotes, tight integration of graphics with text, and well-set typography.<!--more--> The idea for this project is essentially cribbed wholesale from Tufte and R Markdown's Tufte Handout format{% sidenote 'One' 'See [tufte-latex.github.io/tufte-latex/](https://tufte-latex.github.io/tufte-latex/) and [rmarkdown.rstudio.com/tufte_handout_format](http://rmarkdown.rstudio.com/tufte_handout_format.html)' %} This page is an adaptation of the [Tufte Handout PDF](http://rmarkdown.rstudio.com/examples/tufte-handout.pdf).
 
 ## Jekyll customizations
 
@@ -43,19 +43,19 @@ Any of these values can be changed in the ```_sass/_settings.scss``` file before
 ### Color
 
 Although paper handouts obviously have a pure white background, the web is better served by the use of slightly off-white and off-black colors. I picked ```#fffff8``` and ```#111111``` because they are nearly indistinguishable from their 'pure' cousins, but dial down the harsh contrast. Tufte's books are a study in spare, minimalist design. In his book [The Visual Display of Quantitative Information](http://www.edwardtufte.com/tufte/books_vdqi), he uses a red ink to add some visual punctuation to the buff colored paper and dark ink. In that spirit, links are styled using a similar red color.
-  
+
 ### Headings
 
 Tufte CSS uses ```<h1>``` for the document title, ```<p>``` with class ```code``` for the document subtitle, ```<h2>``` for section headings, and ```<h3>``` for low-level headings. More specific headings are not encouraged. If you feel the urge to reach for a heading of level 4 or greater, consider redesigning your document:
 
-    
-> [It is] notable that the Feynman lectures (3 volumes) write about all of physics in 1800 pages, using only 2 levels of hierarchical headings: chapters and A-level heads in the text. It also uses the methodology of *sentences* which then cumulate sequentially into *paragraphs*, rather than the grunts of bullet points. Undergraduate Caltech physics is very complicated material, but it didn’t require an elaborate hierarchy to organize. 
-<cite>[http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB](http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB)</cite> 
+
+> [It is] notable that the Feynman lectures (3 volumes) write about all of physics in 1800 pages, using only 2 levels of hierarchical headings: chapters and A-level heads in the text. It also uses the methodology of *sentences* which then cumulate sequentially into *paragraphs*, rather than the grunts of bullet points. Undergraduate Caltech physics is very complicated material, but it didn’t require an elaborate hierarchy to organize.
+<cite>[http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB](http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB)</cite>
 
 
 As a bonus, this excerpt regarding the use of headings provides an example of using block quotes. Markdown does not have a native ```<cite>``` shorthand, but real html can be sprinkled in with the Markdown text. In the previous example, the ```<cite>``` was preceded with a single return after the quotation itself. The previous blockquote was written in Markdown thusly:
 
-\> ```[It is] notable that the Feynman lectures (3 volumes) write about all of physics in 1800 pages, using only 2 levels of hierarchical headings: chapters and A-level heads in the text. It also uses the methodology of *sentences* which then cumulate sequentially into *paragraphs*, rather than the grunts of bullet points. Undergraduate Caltech physics is very complicated material, but it didn’t require an elaborate hierarchy to organize.``` 
+\> ```[It is] notable that the Feynman lectures (3 volumes) write about all of physics in 1800 pages, using only 2 levels of hierarchical headings: chapters and A-level heads in the text. It also uses the methodology of *sentences* which then cumulate sequentially into *paragraphs*, rather than the grunts of bullet points. Undergraduate Caltech physics is very complicated material, but it didn’t require an elaborate hierarchy to organize.```
 ```<cite>[http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB](http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB)</cite>```
 
 Tufte CSS styles headings ```h1```, ```h2```, and ```h3```, making them nearly identical except for font size. The ```h1``` should be used as a title, the ```h2``` for section headings, and ```h3``` for subsection headings.
@@ -90,9 +90,9 @@ For these reasons, Tufte CSS encourages caution before reaching for a list eleme
 
 ### Margin Figures
 
-{% marginfigure 'mf-id-1' 'assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.'  %}Images and graphics play an integral role in Tufte’s work. To place figures in the margin, use the custom margin figure liquid tag included in the ```_plugins``` directory like so: 
+{% marginfigure 'mf-id-1' 'assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.'  %}Images and graphics play an integral role in Tufte’s work. To place figures in the margin, use the custom margin figure liquid tag included in the ```_plugins``` directory like so:
 
-```{{ "{% marginfigure 'mf-id-whatever' 'assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.' "}} %}```. 
+```{{ "{% marginfigure 'mf-id-whatever' 'assets/img/rhino.png' 'F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zoological Literature,” *Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice* (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s *Visual Explanations*.' "}} %}```.
 
 Note that this tag has *three* parameters. The first is an arbitrary id. This parameter can be named anything as long as it is unique to this post. The second parameter is the path to the image. And the final parameter is whatever caption you want to be displayed with the figure.  All parameters *must* be enclosed in quotes for this simple liquid tag to work!
 
@@ -120,7 +120,7 @@ yields this:
 
 One of the most prominent and distinctive features of Tufte's style is the extensive use of sidenotes and margin notes. Perhaps you have noticed their use in this document already. You are very astute.
 
-There is a wide margin to provide ample room for sidenotes and small figures. There exists a slight semantic distinction between *sidenotes* and *marginnotes*. 
+There is a wide margin to provide ample room for sidenotes and small figures. There exists a slight semantic distinction between *sidenotes* and *marginnotes*.
 
 ### Sidenotes
 
@@ -138,15 +138,15 @@ Margin notes{% marginnote 'mn-id-whatever' 'This is a margin note *without* a su
 
 The Markdown parser being used by this Jekyll theme is Kramdown, which contains some built-in [Mathjax](//www.mathjax.org) support. Both inline and block-level mathematical figures can be added to the content.
 
-For instance, the following inline sequence: 
+For instance, the following inline sequence:
 
-*When {% m %}a \ne 0{% em %}, there are two solutions to {% m %}ax^2 + bx + c = 0{% em %}* 
+*When {% m %}a \ne 0{% em %}, there are two solutions to {% m %}ax^2 + bx + c = 0{% em %}*
 
-is written by enclosing a Mathjax expression with a *Liquid inline tag pair* ('m' and 'em') like so: 
+is written by enclosing a Mathjax expression with a *Liquid inline tag pair* ('m' and 'em') like so:
 
 ```When {{ "{% m "}}%} a \ne 0{{ "{% em "}}%}, there are two solutions to {{ "{% m " }}%}ax^2 + bx + c = 0{{ "{% em " }}%}```
 
-Similarly, this block-level Mathjax expression: 
+Similarly, this block-level Mathjax expression:
 
 {% math %}x = {-b \pm \sqrt{b^2-4ac} \over 2a}.{% endmath %}
 
@@ -166,11 +166,11 @@ The Mathjax integration is tricky, and some things such as the inline matrix not
 
 ## Tables
 
-Tables are, frankly,  a pain in the ass to create. That said, they often are one of the best methods for presenting data. Tabular data are normally presented with right-aligned numbers, left-aligned text, and minimal grid lines. 
+Tables are, frankly,  a pain in the ass to create. That said, they often are one of the best methods for presenting data. Tabular data are normally presented with right-aligned numbers, left-aligned text, and minimal grid lines.
 
-Note that when writing Jekyll Markdown content, there will often be a need to get some dirt under your fingernails and stoop to writing a little honest-to-god html. Yes, all that hideous ```<table>..<thead>..<th>``` nonsense. *And* you must wrap the unholy mess in a ```<div class="table-wrapper">``` tag to ensure that the table stays centered in the main content column. 
+Note that when writing Jekyll Markdown content, there will often be a need to get some dirt under your fingernails and stoop to writing a little honest-to-god html. Yes, all that hideous ```<table>..<thead>..<th>``` nonsense. *And* you must wrap the unholy mess in a ```<div class="table-wrapper">``` tag to ensure that the table stays centered in the main content column.
 
-Tables are designed with an ```overflow:scroll``` property to create slider bars when the viewport is narrow. This is so that you do not collapse all your beautiful data into a jumble of letters and numbers when you view it on your smartphone. 
+Tables are designed with an ```overflow:scroll``` property to create slider bars when the viewport is narrow. This is so that you do not collapse all your beautiful data into a jumble of letters and numbers when you view it on your smartphone.
 
 {% marginnote 'table-1-id' '*Table 1*: A table with default style formatting' %}
 <div class="table-wrapper">
@@ -338,10 +338,9 @@ Which is created by surrounding the code with the *highlight* tag block pair:
 
 ```
 {{ "{% highlight ruby" }} %}
-  module Jekyll 
+  module Jekyll
     blah, blah...
   Liquid::Template.register_tag('fullwidth', Jekyll::RenderFullWidthTag)
 {{ "{% endhighlight" }} %}
 ```
 For some reason, the *linenos* tag modifier in the highlight tag works strangely when it is inserted in a tag. Use it if you like, but check to see how it is being parsed by the Jekyll engine before going live.
-


### PR DESCRIPTION
This eliminates the need to hard-code image and asset paths in the liquid tags. I've updated the Readme with some appropriate information, as well as made a few tweaks and fixed a few typos. Let me know if you have any questions about my changes.

I've also updated the example blog post to change to relative paths, now the examples match exactly to the real code used.

Fixes #15.