### PR TITLE
Adjust full-width captions to clear properly; Adjust sidenote and marginnote margin when occuring inside blockquotes

### DIFF
--- a/css/tufte.scss
+++ b/css/tufte.scss
@@ -249,6 +249,8 @@ img { max-width: 100%; }
 
 li .sidenote, li .marginnote{ margin-right: -80%; } //added to allow for the fact that lists are indented and marginnotes and sidenotes push to right
 
+blockquote .sidenote, blockquote .marginnote { margin-right: -79% }
+
 .sidenote-number { counter-increment: sidenote-counter; }
 
 .sidenote-number:after, .sidenote:before { content: counter(sidenote-counter) " ";

--- a/css/tufte.scss
+++ b/css/tufte.scss
@@ -7,18 +7,18 @@ nav_exclude: true
 /*
 /* Tufte Jekyll blog theme
 /* Based on Tufte CSS by Dave Liepmann ( https://github.com/edwardtufte/tufte-css )
-/* 
+/*
 /* The README.md will show you how to set up your site along with other goodies
 /*****************************************************************************/
 
-// Imports to create final 
- 
+// Imports to create final
+
 @import "../_sass/fonts";
 @import "../_sass/settings";
 @import "../_sass/syntax-highlighting";
 
 // Global Resets
-// 
+//
 * { margin: 0; padding: 0; }
 
 /* clearfix hack after Cederholm (group class name) */
@@ -67,14 +67,14 @@ p > a { @if $link-style == underline
       color: $text-color;
       text-decoration: none;
       border-bottom: 1px solid #777;
-      padding-bottom: 1px; 
+      padding-bottom: 1px;
     }
     @else
     {
       color: $contrast-color;
       text-decoration: none;
     }
-  }  
+  }
 
 body { width: 87.5%;
        margin-left: auto;
@@ -87,7 +87,7 @@ body { width: 87.5%;
        counter-reset: sidenote-counter; }
 
 // --------- Typography stuff -----------//
-// added rational line height and margins ala http://webtypography.net/intro/ 
+// added rational line height and margins ala http://webtypography.net/intro/
 
 h1 { font-weight: 400;
      margin-top: 1.568rem;
@@ -129,7 +129,7 @@ p, li { line-height: 2rem;
 blockquote p {  font-size: 1.1rem;
                 line-height: 1.78181818;
                 margin-top: 1.78181818rem;
-                margin-bottom: 1.78181818rem; 
+                margin-bottom: 1.78181818rem;
                 width: 45%;
                 padding-left: 2.5%;
                 padding-right: 2.5%; }
@@ -169,7 +169,7 @@ th, td{ font-size: 1.2rem;
 
 .booktabs th.nocmid { border-bottom: none; }
 
-.booktabs tbody tr:first-child td,  tr:first-child td { padding-top: 0.65ex; } /* add space between thead row and tbody */ 
+.booktabs tbody tr:first-child td,  tr:first-child td { padding-top: 0.65ex; } /* add space between thead row and tbody */
 
 .booktabs td, td {  padding-left: 0.5em;
                     padding-right: 0.5em;
@@ -214,7 +214,7 @@ ul { width: 45%;
      -webkit-padding-end: 5%;
      list-style-type: none; }
 
-//li { padding: 0.5em 0; } //vertical padding on list items screws up vertical rhythym 
+//li { padding: 0.5em 0; } //vertical padding on list items screws up vertical rhythym
 
 figure, figure img.maincolumn { max-width: 55%;
          -webkit-margin-start: 0;
@@ -232,9 +232,7 @@ figcaption { float: right;
              position: relative;
              max-width: 40%; }
 
-figure.fullwidth figcaption { margin-right: 24%; }
-
-
+figure.fullwidth figcaption { float: left; margin-right: 0%; margin-left: 36%; }
 
 img { max-width: 100%; }
 
@@ -255,7 +253,7 @@ li .sidenote, li .marginnote{ margin-right: -80%; } //added to allow for the fac
 
 .sidenote-number:after, .sidenote:before { content: counter(sidenote-counter) " ";
                                            font-family: et-bembo-roman-old-style;
-                                           color: $contrast-color; //added color 
+                                           color: $contrast-color; //added color
                                            position: relative;
                                            vertical-align: baseline; }
 
@@ -303,7 +301,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
 
 @media (max-width: 760px) { label.margin-toggle:not(.sidenote-number) { display: inline; color: $contrast-color; }
                             .sidenote, .marginnote { display: none; }
-                            .margin-toggle:checked + .sidenote, 
+                            .margin-toggle:checked + .sidenote,
                             .margin-toggle:checked + .marginnote { display: block;
                                                                    float: left;
                                                                    left: 1rem;
@@ -313,7 +311,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
                                                                    vertical-align: baseline;
                                                                    position: relative; }
                             label { cursor: pointer; }
-                            pre, pre code, p code, p pre code { width: 90%; 
+                            pre, pre code, p code, p pre code { width: 90%;
                                        padding: 0; }
                             .table-caption { display: block;
                                              float: right;
@@ -337,7 +335,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
 .smaller { font-size: 80%;}
 //Nav and Footer styling area
 
-header > nav.group, body footer { 
+header > nav.group, body footer {
   width: 95%;
   padding-top: 2rem;
 }
@@ -440,9 +438,9 @@ hr.slender {
     height: 1px;
     margin-top: 1.4rem;
     margin-bottom:1.4rem;
-    background-image: -webkit-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0)); 
-    background-image:    -moz-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0)); 
-    background-image:     -ms-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0)); 
+    background-image: -webkit-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0));
+    background-image:    -moz-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0));
+    background-image:     -ms-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0));
     background-image:      -o-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,0.75), rgba(0,0,0,0));
 }
 // End of front listing page stuff
@@ -463,7 +461,7 @@ hr.slender {
     *:before,
     *:after {
         background: transparent !important;
-        color: #000 !important; // Black prints faster:http://www.sanbeiji.com/archives/953 
+        color: #000 !important; // Black prints faster:http://www.sanbeiji.com/archives/953
         box-shadow: none !important;
         text-shadow: none !important;
     }
@@ -471,10 +469,10 @@ hr.slender {
         margin: 0.75in 0.5in 0.75in 0.5in;
         orphans:4; widows:2;
     }
-    
+
     body {
         font-size:  12pt;
-          
+
     }
     html body span.print-footer{
       font-family: $sans-font;
@@ -588,4 +586,4 @@ hr.slender {
 .icon-box-add:before {
   content: "\e60e";
 }
-/*-- End of Icomoon icon font section --*/            
+/*-- End of Icomoon icon font section --*/


### PR DESCRIPTION
Fixes #23 and #24 

Here is a test page for the fixes: http://fullwidthtest.surge.sh/test/

* The caption clears properly while the width of the caption is maintained across screen size transitions.
* Sidenotes and Marginnotes have correct margins when occurring inside blockquotes

The first change is at [L235](https://github.com/xHN35RQ/tufte-jekyll/commit/c581a171cb985c944d5a52f31d6c74d9fe005f27#diff-66f4276a3e8f4e22f4456055f556d7bfL235) however my editor apparently removed a lot of trailing whitespaces, thus the high number of altered lines in that specific diff