### PR TITLE
remove lines that are now defaults in Jekyll 3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,12 +5,7 @@ author: clay harmon
 simple_search: http://google.com/search
 description: A Jekyll theme for content-rich sites
 name: tufte
-markdown: Kramdown
-kramdown:  
-  input: GFM
-  syntax_highlighter: rouge
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"
-highlighter: rouge
 permalink: /articles/:short_year/:title
 timezone: America/New_York
 excerpt_separator: <!--more-->  # you can specify your own separator, of course.


### PR DESCRIPTION
Github pages have been updated to Jekyll 3.0 and support Rouge highlighting and fenced code blocks by default.

Closes #31 