### PR TITLE
Fix #54

### DIFF
--- a/_plugins/main_column_img.rb
+++ b/_plugins/main_column_img.rb
@@ -15,9 +15,9 @@ module Jekyll
     def render(context)
       baseurl = context.registers[:site].config['baseurl']
       if @text[0].start_with?('http://', 'https://','//')
-        "<figure><figcaption>#{@text[1]}</figcaption><img src='#{@text[0]}'/></figure>"
+        "<figure><figcaption><span markdown='1'>#{@text[1]}</span></figcaption><img src='#{@text[0]}'/></figure>"
       else
-        "<figure><figcaption>#{@text[1]}</figcaption><img src='#{baseurl}/#{@text[0]}'/></figure>"
+        "<figure><figcaption><span markdown='1'>#{@text[1]}</span></figcaption><img src='#{baseurl}/#{@text[0]}'/></figure>"
       end
     end
   end


### PR DESCRIPTION
Rendering of markdown inside an HTML block tag is disallowed per default (`<figcaption>` is per default rendered as a block by most browsers, cf. http://www.w3schools.com/tags/tag_figcaption.asp). In order to allow markdown to be rendered, kramdown has the attribute `markdown` which can be set to `1` to allow rendering. Hence, this commit adds a span with `markdown='1'` to the `<figcaption>` tag in `main_column_img.rb`. Cf. also http://stackoverflow.com/a/35276926/731040.