### PR TITLE
kramdown options in _config.yml for proper code rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ simple_search: http://google.com/search
 description: A Jekyll theme for content-rich sites
 name: tufte
 markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 permalink: /articles/:short_year/:title
 timezone: America/New_York


### PR DESCRIPTION
I downloaded and ran the sample page with the theme but triple-backtick code was not rendered properly. Adding these settings to `_config.yml` fixes this.

![yamlfix](https://user-images.githubusercontent.com/7822872/39967777-24e5bb50-56c2-11e8-9107-8566757b621f.png)
