### PR TITLE
Support newer versions of Ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       hitimes
     toml (0.1.2)
       parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Per https://github.com/brianmario/yajl-ruby/issues/164 on Ruby >= 2.4 there needs to be an adjustment made. I am unsure of the best syntax but this worked.